### PR TITLE
Bubble up TCP connection errors

### DIFF
--- a/lib/marionette/drivers/tcp.js
+++ b/lib/marionette/drivers/tcp.js
@@ -73,8 +73,13 @@ Tcp.prototype._connect = function connect(callbackpromises) {
     tries: this.tries
   };
   retrySocket.waitForSocket(options, function(err, socket) {
-    debug('got socket starting command stream');
+    debug('got socket starting command stream %o', { err: err });
+
     if (callbackpromises){
+      if (err) {
+        return callbackpromises(err)
+      }
+
       this.callbackpromises = callbackpromises;
     }
     this.socket = socket;


### PR DESCRIPTION
This will allow us to catch errors thrown during the initial connection, like in cypress-io/cypress#6356